### PR TITLE
0.1.1 dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## v0.2.0 — 2026-03-19
+## v0.1.1 — 2026-03-19
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.2.0 — 2026-03-19
+
+### Bug Fixes
+
+- **Importer not running** — Replaced `supercronic` (glibc binary incompatible with Alpine/musl) with Alpine's built-in `crond`.
+- **Broken concurrent-import lock** — PostgreSQL advisory lock was session-scoped and released immediately; replaced with `mkdir`-based file lock.
+- **Grafana panels failing** — Added empty materialized views at database init so panels load before first import; granted `pg_read_all_stats` for the Database Size panel.
+- **Removed auto-import on startup** — Initial import no longer runs automatically; must be triggered manually or by cron schedule.
+
+### Features
+
+- **Skip unchanged imports** — Importer checks S3 ETags and skips the full import cycle when data hasn't changed and last import succeeded.
+- **Health endpoint** — Added `v_health` SQL view exposed via PostgREST at `/v_health` for external uptime monitors.
+- **La Selva Biological Station dashboard** — Observations, species, seasonal patterns, and map for the La Selva area in Costa Rica.
+- **Steele Creek Park — Frogs dashboard** — Frog observations, species list, seasonal activity, and map for Steele Creek Park in Bristol, TN.
+- **iNaturalist HotSpots dashboard** — Global observation density heatmap, top hotspots table, and distribution breakdown.
+
+### Documentation
+
+- Added development guide covering: manual imports, test data seeding, alert SQL testing, and log viewing.
+- Added filtered data export examples using PostgREST with `Accept: text/csv`.
+
 ## v0.1.0 — 2026-03-15
 
 Initial release of Observa, a Dockerized platform for hosting and exploring iNaturalist Open Data.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The importer runs on the schedule defined by `IMPORT_CRON`. Each run uses a zero
 
 Safety features:
 
-- Advisory lock prevents concurrent imports
+- File lock prevents concurrent imports
 - Row count validation aborts if data drops >50% from previous import
 - Failed imports are automatically logged with error details
 - Staging tables are cleaned up on failure (live data preserved)
@@ -118,6 +118,16 @@ To check import logs:
 docker compose exec postgres psql -U observa -d inaturalist \
   -c "SELECT * FROM import_log ORDER BY id DESC LIMIT 5;"
 ```
+
+## Health Endpoint
+
+A `v_health` view is exposed via PostgREST for external uptime monitors:
+
+```bash
+curl "http://localhost:3001/v_health"
+```
+
+Returns the last import status, hours since last import, row counts, and any error message. This can be polled by monitoring tools without requiring Grafana access.
 
 ## REST API
 
@@ -138,6 +148,36 @@ curl "http://localhost:3001/mv_quality_grade_counts"
 ```
 
 See the [PostgREST documentation](https://postgrest.org/en/stable/references/api.html) for full query syntax.
+
+### Filtered data export
+
+PostgREST supports CSV output via the `Accept` header, which is often more useful than the full-table dumps from `export.sh`:
+
+```bash
+# Export research-grade observations as CSV
+curl -H "Accept: text/csv" \
+  "http://localhost:3001/observations?quality_grade=eq.research&limit=1000" > research.csv
+
+# Export observations for a specific taxon
+curl -H "Accept: text/csv" \
+  "http://localhost:3001/observations?taxon_id=eq.3726&limit=5000" > taxon_obs.csv
+
+# Export observations within a date range
+curl -H "Accept: text/csv" \
+  "http://localhost:3001/observations?observed_on=gte.2025-01-01&observed_on=lte.2025-12-31" > year_2025.csv
+
+# Export observations within a bounding box (lat/lon)
+curl -H "Accept: text/csv" \
+  "http://localhost:3001/observations?latitude=gte.10.0&latitude=lte.11.0&longitude=gte.-84.5&longitude=lte.-83.5" > bbox.csv
+
+# Combine filters — research-grade birds in 2025
+curl -H "Accept: text/csv" \
+  "http://localhost:3001/observations?quality_grade=eq.research&observed_on=gte.2025-01-01&observed_on=lte.2025-12-31&select=observation_uuid,taxon_id,observed_on,latitude,longitude" > filtered.csv
+
+# Export photo license breakdown
+curl -H "Accept: text/csv" \
+  "http://localhost:3001/mv_photo_licenses?order=total.desc" > licenses.csv
+```
 
 ### API security notice
 
@@ -220,6 +260,94 @@ The following alerts are pre-configured:
 - **Observation count drop** — warns if count drops >10% between imports
 
 Configure notification channels in Grafana under Alerting > Contact Points.
+
+## Development
+
+### Running the importer against an existing database
+
+If the database is already populated, you can re-run the importer without downloading from S3. The importer uses ETag caching, so if cached files exist and haven't changed upstream, the download phase is skipped automatically:
+
+```bash
+docker compose exec importer /bin/sh /import.sh
+```
+
+To force a fresh download (e.g., after clearing the cache volume):
+
+```bash
+docker compose down importer
+docker volume rm observa_import_cache
+docker compose up -d importer
+docker compose exec importer /bin/sh /import.sh
+```
+
+### Seeding a small test dataset
+
+For local testing without downloading the full ~10 GB dataset, you can insert sample data directly:
+
+```bash
+docker compose exec postgres psql -U observa -d inaturalist <<'SQL'
+INSERT INTO taxa (taxon_id, name, rank, rank_level, active)
+VALUES (1, 'Aves', 'class', 50, true),
+       (2, 'Turdus migratorius', 'species', 10, true);
+
+INSERT INTO observers (observer_id, login, name)
+VALUES (1, 'testuser', 'Test User');
+
+INSERT INTO observations (observation_uuid, observer_id, latitude, longitude, taxon_id, quality_grade, observed_on)
+VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 1, 36.5, -82.5, 2, 'research', '2025-06-15');
+
+INSERT INTO photos (photo_uuid, photo_id, observation_uuid, observer_id, license)
+VALUES ('b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 1, 'CC-BY');
+SQL
+```
+
+Then refresh the materialized views so dashboards reflect the test data:
+
+```bash
+docker compose exec postgres psql -U observa -d inaturalist -f /docker-entrypoint-initdb.d/../scripts/create-materialized-views.sql
+```
+
+Note: the views script is mounted at `/scripts` inside the importer container, but accessible from the postgres container only if you mount it separately. Alternatively, run it from the importer:
+
+```bash
+docker compose exec importer psql -f /scripts/create-materialized-views.sql
+```
+
+### Testing alert SQL
+
+Grafana alert rules query PostgreSQL directly. To test alert queries from the command line:
+
+```bash
+# Import stale alert — checks hours since last successful import
+docker compose exec postgres psql -U observa -d inaturalist -c "
+  SELECT EXTRACT(EPOCH FROM now() - max(finished_at)) / 3600 AS hours_since_import
+  FROM import_log WHERE status = 'completed';
+"
+
+# Observation count drop alert
+docker compose exec postgres psql -U observa -d inaturalist -c "
+  SELECT a.observations_count AS current, b.observations_count AS previous,
+         round(100.0 * (b.observations_count - a.observations_count) / b.observations_count, 1) AS drop_pct
+  FROM import_log a, import_log b
+  WHERE a.id = (SELECT max(id) FROM import_log WHERE status = 'completed')
+    AND b.id = (SELECT max(id) FROM import_log WHERE status = 'completed' AND id < a.id);
+"
+```
+
+### Rebuilding a single service
+
+```bash
+docker compose up -d --build importer   # rebuild and restart importer only
+docker compose up -d --build postgres   # rebuild postgres (data persists in volume)
+```
+
+### Viewing logs
+
+```bash
+docker compose logs -f importer         # follow importer logs
+docker compose logs --tail 50 postgres  # last 50 lines from postgres
+docker compose logs                     # all services
+```
 
 ## Data Source
 

--- a/db/init/01-schema.sql
+++ b/db/init/01-schema.sql
@@ -61,6 +61,9 @@ CREATE TABLE observers (
 
 CREATE INDEX idx_import_log_status_id ON import_log (status, id DESC);
 
+-- Allow the main user to query database size in Grafana
+GRANT pg_read_all_stats TO CURRENT_USER;
+
 -- Read-only role for API access
 DO $$
 BEGIN

--- a/db/init/01-schema.sql
+++ b/db/init/01-schema.sql
@@ -64,6 +64,22 @@ CREATE INDEX idx_import_log_status_id ON import_log (status, id DESC);
 -- Allow the main user to query database size in Grafana
 GRANT pg_read_all_stats TO CURRENT_USER;
 
+-- Health endpoint for external uptime monitors (exposed via PostgREST)
+CREATE OR REPLACE VIEW v_health AS
+SELECT
+    il.status AS last_import_status,
+    il.finished_at AS last_import_at,
+    round(EXTRACT(EPOCH FROM now() - il.finished_at) / 3600, 1) AS hours_since_import,
+    il.observations_count,
+    il.photos_count,
+    il.taxa_count,
+    il.observers_count,
+    il.duration_seconds AS last_import_duration_seconds,
+    il.error_message AS last_error
+FROM import_log il
+ORDER BY il.id DESC
+LIMIT 1;
+
 -- Read-only role for API access
 DO $$
 BEGIN

--- a/db/init/03-materialized-views.sql
+++ b/db/init/03-materialized-views.sql
@@ -1,0 +1,30 @@
+-- Create empty materialized views so Grafana panels load before the first import.
+-- The importer will DROP and recreate these with real data after each successful import.
+
+CREATE MATERIALIZED VIEW mv_observations_monthly AS
+SELECT null::timestamptz AS month, 0::bigint AS observation_count WHERE false;
+CREATE UNIQUE INDEX ON mv_observations_monthly (month);
+
+CREATE MATERIALIZED VIEW mv_quality_grade_counts AS
+SELECT null::varchar AS quality_grade, 0::bigint AS total WHERE false;
+CREATE UNIQUE INDEX ON mv_quality_grade_counts (quality_grade);
+
+CREATE MATERIALIZED VIEW mv_top_taxa AS
+SELECT null::integer AS taxon_id, null::varchar AS name, null::varchar AS rank, 0::bigint AS observation_count WHERE false;
+CREATE UNIQUE INDEX ON mv_top_taxa (taxon_id);
+
+CREATE MATERIALIZED VIEW mv_top_observers AS
+SELECT null::integer AS observer_id, null::varchar AS login, null::varchar AS name, 0::bigint AS observation_count WHERE false;
+CREATE UNIQUE INDEX ON mv_top_observers (observer_id);
+
+CREATE MATERIALIZED VIEW mv_photo_licenses AS
+SELECT null::varchar AS license, 0::bigint AS total WHERE false;
+CREATE UNIQUE INDEX ON mv_photo_licenses (license);
+
+CREATE MATERIALIZED VIEW mv_observations_by_rank AS
+SELECT null::varchar AS rank, 0::bigint AS observation_count WHERE false;
+CREATE UNIQUE INDEX ON mv_observations_by_rank (rank);
+
+CREATE MATERIALIZED VIEW mv_observations_grid AS
+SELECT null::geometry AS grid_geom, 0::bigint AS observation_count WHERE false;
+CREATE UNIQUE INDEX ON mv_observations_grid (grid_geom);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - ./db/scripts:/scripts:ro
       - import_cache:/cache
     healthcheck:
-      test: ["CMD-SHELL", "pgrep supercronic"]
+      test: ["CMD-SHELL", "pgrep crond"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/grafana/provisioning/dashboards/hotspots.json
+++ b/grafana/provisioning/dashboards/hotspots.json
@@ -1,0 +1,177 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Total Grid Cells",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT count(*) AS \"Grid Cells\" FROM mv_observations_grid;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 2,
+      "title": "Most Observed Grid Cell",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT observation_count AS \"Max Observations\", round(ST_Y(grid_geom)::numeric, 1) || ', ' || round(ST_X(grid_geom)::numeric, 1) AS \"Location\" FROM mv_observations_grid ORDER BY observation_count DESC LIMIT 1;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "orange", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 3,
+      "title": "Median Observations per Cell",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY observation_count)::bigint AS \"Median\" FROM mv_observations_grid;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 4,
+      "title": "Global Observation Density",
+      "type": "geomap",
+      "gridPos": { "h": 16, "w": 24, "x": 0, "y": 4 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT ST_Y(grid_geom) AS latitude, ST_X(grid_geom) AS longitude, observation_count AS metric FROM mv_observations_grid ORDER BY observation_count DESC LIMIT 10000;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": {
+        "view": { "id": "coords", "lat": 20, "lon": 0, "zoom": 2 },
+        "basemap": { "type": "default", "name": "OpenStreetMap" },
+        "layers": [
+          {
+            "type": "heatmap",
+            "name": "Observation Density",
+            "config": {
+              "weight": { "field": "metric", "fixed": 1 },
+              "radius": { "fixed": 20 },
+              "blur": { "fixed": 15 },
+              "opacity": 0.6
+            },
+            "location": { "mode": "coords", "latitude": "latitude", "longitude": "longitude" }
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "title": "Top 50 HotSpots",
+      "type": "table",
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 20 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT ROW_NUMBER() OVER (ORDER BY observation_count DESC) AS rank, round(ST_Y(grid_geom)::numeric, 2) AS latitude, round(ST_X(grid_geom)::numeric, 2) AS longitude, observation_count AS observations FROM mv_observations_grid ORDER BY observation_count DESC LIMIT 50;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": { "showHeader": true }
+    },
+    {
+      "id": 6,
+      "title": "Observation Count Distribution",
+      "type": "barchart",
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 20 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT CASE WHEN observation_count < 10 THEN '1-9' WHEN observation_count < 100 THEN '10-99' WHEN observation_count < 1000 THEN '100-999' WHEN observation_count < 10000 THEN '1K-9.9K' WHEN observation_count < 100000 THEN '10K-99K' ELSE '100K+' END AS bucket, count(*) AS grid_cells FROM mv_observations_grid GROUP BY CASE WHEN observation_count < 10 THEN 1 WHEN observation_count < 100 THEN 2 WHEN observation_count < 1000 THEN 3 WHEN observation_count < 10000 THEN 4 WHEN observation_count < 100000 THEN 5 ELSE 6 END, bucket ORDER BY CASE WHEN observation_count < 10 THEN 1 WHEN observation_count < 100 THEN 2 WHEN observation_count < 1000 THEN 3 WHEN observation_count < 10000 THEN 4 WHEN observation_count < 100000 THEN 5 ELSE 6 END;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "orientation": "vertical" }
+    },
+    {
+      "id": 7,
+      "title": "Top HotSpots Map (Markers)",
+      "type": "geomap",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 30 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT ST_Y(grid_geom) AS latitude, ST_X(grid_geom) AS longitude, observation_count AS metric FROM mv_observations_grid ORDER BY observation_count DESC LIMIT 100;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": {
+        "view": { "id": "coords", "lat": 20, "lon": 0, "zoom": 2 },
+        "basemap": { "type": "default", "name": "OpenStreetMap" },
+        "layers": [
+          {
+            "type": "markers",
+            "name": "Top 100 HotSpots",
+            "config": {
+              "size": { "field": "metric", "min": 5, "max": 30 },
+              "color": { "field": "metric", "fixed": "red" },
+              "fillOpacity": 0.6
+            },
+            "location": { "mode": "coords", "latitude": "latitude", "longitude": "longitude" }
+          }
+        ]
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["inaturalist", "observa", "hotspots"],
+  "templating": { "list": [] },
+  "time": { "from": "now-5y", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "iNaturalist HotSpots",
+  "uid": "inaturalist-hotspots",
+  "version": 1
+}

--- a/grafana/provisioning/dashboards/la-selva.json
+++ b/grafana/provisioning/dashboards/la-selva.json
@@ -1,0 +1,237 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Total Observations",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT count(*) AS \"Observations\" FROM observations WHERE latitude BETWEEN 10.40 AND 10.47 AND longitude BETWEEN -84.05 AND -83.97;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 2,
+      "title": "Unique Species",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT count(DISTINCT o.taxon_id) AS \"Species\" FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE t.rank = 'species' AND o.latitude BETWEEN 10.40 AND 10.47 AND o.longitude BETWEEN -84.05 AND -83.97;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 3,
+      "title": "Unique Observers",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT count(DISTINCT observer_id) AS \"Observers\" FROM observations WHERE latitude BETWEEN 10.40 AND 10.47 AND longitude BETWEEN -84.05 AND -83.97;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 4,
+      "title": "Research Grade %",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT round(100.0 * sum(CASE WHEN quality_grade = 'research' THEN 1 ELSE 0 END) / NULLIF(count(*), 0), 1) AS \"Research Grade %\" FROM observations WHERE latitude BETWEEN 10.40 AND 10.47 AND longitude BETWEEN -84.05 AND -83.97;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 30 }, { "color": "green", "value": 50 }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 5,
+      "title": "Observations Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 4 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT date_trunc('month', observed_on) AS time, count(*) AS observations FROM observations WHERE observed_on IS NOT NULL AND latitude BETWEEN 10.40 AND 10.47 AND longitude BETWEEN -84.05 AND -83.97 GROUP BY 1 ORDER BY 1;",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list" }, "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 6,
+      "title": "Top 20 Species",
+      "type": "barchart",
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT t.name AS species, count(*) AS observations FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE t.rank = 'species' AND o.latitude BETWEEN 10.40 AND 10.47 AND o.longitude BETWEEN -84.05 AND -83.97 GROUP BY t.name ORDER BY observations DESC LIMIT 20;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "orientation": "horizontal" }
+    },
+    {
+      "id": 7,
+      "title": "Quality Grade Distribution",
+      "type": "piechart",
+      "gridPos": { "h": 10, "w": 6, "x": 12, "y": 12 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT quality_grade AS grade, count(*) AS total FROM observations WHERE quality_grade IS NOT NULL AND latitude BETWEEN 10.40 AND 10.47 AND longitude BETWEEN -84.05 AND -83.97 GROUP BY quality_grade ORDER BY total DESC;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "right" }, "pieType": "donut" }
+    },
+    {
+      "id": 8,
+      "title": "Taxonomic Breakdown",
+      "type": "piechart",
+      "gridPos": { "h": 10, "w": 6, "x": 18, "y": 12 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT t.rank, count(*) AS total FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE t.rank IS NOT NULL AND o.latitude BETWEEN 10.40 AND 10.47 AND o.longitude BETWEEN -84.05 AND -83.97 GROUP BY t.rank ORDER BY total DESC;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "right" }, "pieType": "donut" }
+    },
+    {
+      "id": 9,
+      "title": "Observation Map",
+      "type": "geomap",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 22 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT latitude, longitude, t.name AS species FROM observations o LEFT JOIN taxa t ON o.taxon_id = t.taxon_id WHERE o.geom IS NOT NULL AND o.latitude BETWEEN 10.40 AND 10.47 AND o.longitude BETWEEN -84.05 AND -83.97 LIMIT 5000;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": {
+        "view": { "id": "coords", "lat": 10.43, "lon": -84.01, "zoom": 14 },
+        "basemap": { "type": "default", "name": "OpenStreetMap" },
+        "layers": [
+          {
+            "type": "markers",
+            "name": "Observations",
+            "config": {
+              "size": { "fixed": 5 },
+              "color": { "fixed": "green" },
+              "fillOpacity": 0.6
+            },
+            "location": { "mode": "coords", "latitude": "latitude", "longitude": "longitude" }
+          }
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "title": "Top Observers",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 34 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT ob.login, ob.name, count(*) AS observations FROM observations o JOIN observers ob ON o.observer_id = ob.observer_id WHERE o.latitude BETWEEN 10.40 AND 10.47 AND o.longitude BETWEEN -84.05 AND -83.97 GROUP BY ob.login, ob.name ORDER BY observations DESC LIMIT 20;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": { "showHeader": true }
+    },
+    {
+      "id": 11,
+      "title": "Seasonal Patterns",
+      "type": "barchart",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 34 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT to_char(to_date(EXTRACT(MONTH FROM observed_on)::text, 'MM'), 'Mon') AS month_name, count(*) AS observations FROM observations WHERE observed_on IS NOT NULL AND latitude BETWEEN 10.40 AND 10.47 AND longitude BETWEEN -84.05 AND -83.97 GROUP BY EXTRACT(MONTH FROM observed_on), month_name ORDER BY EXTRACT(MONTH FROM observed_on);",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "orientation": "vertical" }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["inaturalist", "observa", "la-selva"],
+  "templating": { "list": [] },
+  "time": { "from": "now-5y", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "La Selva Biological Station",
+  "uid": "la-selva",
+  "version": 1
+}

--- a/grafana/provisioning/dashboards/steele-creek-frogs.json
+++ b/grafana/provisioning/dashboards/steele-creek-frogs.json
@@ -1,0 +1,205 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Total Frog Observations",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT count(*) AS \"Observations\" FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE o.latitude BETWEEN 36.53 AND 36.60 AND o.longitude BETWEEN -82.22 AND -82.13 AND t.ancestry LIKE '%/20979/%' OR (t.taxon_id = 20979 AND o.latitude BETWEEN 36.53 AND 36.60 AND o.longitude BETWEEN -82.22 AND -82.13);",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 2,
+      "title": "Unique Frog Species",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT count(DISTINCT o.taxon_id) AS \"Species\" FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE t.rank = 'species' AND o.latitude BETWEEN 36.53 AND 36.60 AND o.longitude BETWEEN -82.22 AND -82.13 AND (t.ancestry LIKE '%/20979/%' OR t.taxon_id = 20979);",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 3,
+      "title": "Unique Observers",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT count(DISTINCT o.observer_id) AS \"Observers\" FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE o.latitude BETWEEN 36.53 AND 36.60 AND o.longitude BETWEEN -82.22 AND -82.13 AND (t.ancestry LIKE '%/20979/%' OR t.taxon_id = 20979);",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 4,
+      "title": "Research Grade %",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT round(100.0 * sum(CASE WHEN o.quality_grade = 'research' THEN 1 ELSE 0 END) / NULLIF(count(*), 0), 1) AS \"Research Grade %\" FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE o.latitude BETWEEN 36.53 AND 36.60 AND o.longitude BETWEEN -82.22 AND -82.13 AND (t.ancestry LIKE '%/20979/%' OR t.taxon_id = 20979);",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 30 }, { "color": "green", "value": 50 }] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+    },
+    {
+      "id": 5,
+      "title": "Frog Observations Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 4 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT date_trunc('month', o.observed_on) AS time, count(*) AS observations FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE o.observed_on IS NOT NULL AND o.latitude BETWEEN 36.53 AND 36.60 AND o.longitude BETWEEN -82.22 AND -82.13 AND (t.ancestry LIKE '%/20979/%' OR t.taxon_id = 20979) GROUP BY 1 ORDER BY 1;",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list" }, "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 6,
+      "title": "Frog Species List",
+      "type": "barchart",
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT t.name AS species, count(*) AS observations FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE t.rank = 'species' AND o.latitude BETWEEN 36.53 AND 36.60 AND o.longitude BETWEEN -82.22 AND -82.13 AND (t.ancestry LIKE '%/20979/%' OR t.taxon_id = 20979) GROUP BY t.name ORDER BY observations DESC LIMIT 20;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "orientation": "horizontal" }
+    },
+    {
+      "id": 7,
+      "title": "Seasonal Activity",
+      "type": "barchart",
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT to_char(to_date(EXTRACT(MONTH FROM o.observed_on)::text, 'MM'), 'Mon') AS month_name, count(*) AS observations FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE o.observed_on IS NOT NULL AND o.latitude BETWEEN 36.53 AND 36.60 AND o.longitude BETWEEN -82.22 AND -82.13 AND (t.ancestry LIKE '%/20979/%' OR t.taxon_id = 20979) GROUP BY EXTRACT(MONTH FROM o.observed_on), month_name ORDER BY EXTRACT(MONTH FROM o.observed_on);",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "orientation": "vertical" }
+    },
+    {
+      "id": 8,
+      "title": "Observation Map",
+      "type": "geomap",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 22 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT o.latitude, o.longitude, t.name AS species, o.quality_grade FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id WHERE o.geom IS NOT NULL AND o.latitude BETWEEN 36.53 AND 36.60 AND o.longitude BETWEEN -82.22 AND -82.13 AND (t.ancestry LIKE '%/20979/%' OR t.taxon_id = 20979) LIMIT 5000;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": {
+        "view": { "id": "coords", "lat": 36.565, "lon": -82.175, "zoom": 14 },
+        "basemap": { "type": "default", "name": "OpenStreetMap" },
+        "layers": [
+          {
+            "type": "markers",
+            "name": "Frog Observations",
+            "config": {
+              "size": { "fixed": 7 },
+              "color": { "fixed": "green" },
+              "fillOpacity": 0.7
+            },
+            "location": { "mode": "coords", "latitude": "latitude", "longitude": "longitude" }
+          }
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "title": "Top Observers",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 34 },
+      "datasource": { "type": "postgres", "uid": "inaturalist" },
+      "targets": [
+        {
+          "rawSql": "SELECT ob.login, ob.name, count(*) AS observations, count(DISTINCT o.taxon_id) AS species_seen FROM observations o JOIN taxa t ON o.taxon_id = t.taxon_id JOIN observers ob ON o.observer_id = ob.observer_id WHERE o.latitude BETWEEN 36.53 AND 36.60 AND o.longitude BETWEEN -82.22 AND -82.13 AND (t.ancestry LIKE '%/20979/%' OR t.taxon_id = 20979) GROUP BY ob.login, ob.name ORDER BY observations DESC LIMIT 20;",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": { "showHeader": true }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["inaturalist", "observa", "steele-creek", "frogs"],
+  "templating": { "list": [] },
+  "time": { "from": "now-5y", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Steele Creek Park — Frogs",
+  "uid": "steele-creek-frogs",
+  "version": 1
+}

--- a/importer/Dockerfile
+++ b/importer/Dockerfile
@@ -7,16 +7,7 @@ RUN apk add --no-cache \
     postgresql16-client \
     aws-cli \
     curl \
-    gzip \
-    util-linux
-
-# Install supercronic for container-friendly cron
-ARG SUPERCRONIC_VERSION=v0.2.33
-ARG SUPERCRONIC_SHA1SUM=71b0d58cc53f6bd72cf2f293e09e294b79c666d8
-RUN curl -fsSLO "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-amd64" \
-    && echo "${SUPERCRONIC_SHA1SUM}  supercronic-linux-amd64" | sha1sum -c - \
-    && chmod +x supercronic-linux-amd64 \
-    && mv supercronic-linux-amd64 /usr/local/bin/supercronic
+    gzip
 
 COPY import.sh /import.sh
 RUN chmod +x /import.sh

--- a/importer/Dockerfile
+++ b/importer/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
     postgresql16-client \
     aws-cli \
     curl \
-    gzip
+    gzip \
+    util-linux
 
 # Install supercronic for container-friendly cron
 ARG SUPERCRONIC_VERSION=v0.2.33

--- a/importer/entrypoint.sh
+++ b/importer/entrypoint.sh
@@ -8,9 +8,9 @@ if [ "$PGPASSWORD" = "changeme" ]; then
 fi
 
 # Generate crontab from environment variable
-echo "${IMPORT_CRON:-0 3 * * *} /import.sh" > /tmp/crontab
+echo "${IMPORT_CRON:-0 3 * * *} /bin/sh /import.sh >> /proc/1/fd/1 2>&1" > /var/spool/cron/crontabs/root
 
 echo "Starting importer with schedule: ${IMPORT_CRON:-0 3 * * *}"
 echo "Run '/import.sh' manually inside the container to trigger an immediate import."
 
-exec supercronic /tmp/crontab
+exec crond -f -l 2

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -193,12 +193,9 @@ COMMIT;
 SQL
     SWAP_COMPLETE=1
 
-    log "Dropping materialized views and old tables..."
+    log "Dropping old tables..."
     psql -v ON_ERROR_STOP=1 <<SQL
-DROP MATERIALIZED VIEW IF EXISTS mv_observations_monthly, mv_quality_grade_counts,
-    mv_top_taxa, mv_top_observers, mv_photo_licenses, mv_observations_by_rank,
-    mv_observations_grid;
-DROP TABLE IF EXISTS observations_old, photos_old, taxa_old, observers_old;
+DROP TABLE IF EXISTS observations_old, photos_old, taxa_old, observers_old CASCADE;
 SQL
 }
 

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -8,6 +8,8 @@ CACHE_DIR="/cache"
 SCRIPTS_DIR="/scripts"
 IMPORT_ID=""
 SWAP_COMPLETE=0
+LOCK_DIR="/tmp/import.lock"
+FILES_CHANGED=0
 
 log() { echo "[$(date -u '+%Y-%m-%d %H:%M:%S UTC')] $*"; }
 
@@ -30,7 +32,8 @@ cleanup() {
     if [ "$SWAP_COMPLETE" -eq 0 ]; then
         psql -qtAX -c "DROP TABLE IF EXISTS observations_staging, photos_staging, taxa_staging, observers_staging CASCADE;" 2>/dev/null || true
     fi
-    # File lock is released automatically when the script exits
+    # Release lock
+    rmdir "$LOCK_DIR" 2>/dev/null || true
     # Clean up working files (cache is preserved)
     rm -f "${DATA_DIR}"/*.csv
 }
@@ -76,6 +79,7 @@ download_files() {
         log "  ${file}: downloading..."
         aws s3 cp ${AWS_ARGS} "${S3_BUCKET}/${file}" "${CACHED_FILE}"
         echo "$REMOTE_ETAG" > "$ETAG_FILE"
+        FILES_CHANGED=1
     done
 }
 
@@ -214,10 +218,9 @@ trap cleanup EXIT
 
 wait_for_postgres
 
-# Acquire file lock to prevent concurrent imports (held for entire script lifetime)
-LOCK_FILE="/tmp/import.lock"
-exec 9>"$LOCK_FILE"
-if ! flock -n 9; then
+# Acquire lock to prevent concurrent imports (mkdir is atomic)
+LOCK_DIR="/tmp/import.lock"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
     log "ERROR: Another import is already in progress. Exiting."
     exit 1
 fi
@@ -228,6 +231,17 @@ START_TIME=$(date +%s)
 IMPORT_ID=$(psql -qtAX -c "INSERT INTO import_log (started_at) VALUES (now()) RETURNING id;")
 
 download_files
+
+# Skip import if no files changed and last import was successful
+if [ "$FILES_CHANGED" -eq 0 ]; then
+    LAST_STATUS=$(psql -qtAX -c "SELECT status FROM import_log ORDER BY id DESC LIMIT 1;" 2>/dev/null || echo "")
+    if [ "$LAST_STATUS" = "completed" ]; then
+        log "No new data and last import succeeded. Skipping."
+        exit 0
+    fi
+    log "No new data but last import was not successful. Re-importing."
+fi
+
 validate_files
 load_staging
 swap_tables

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -30,8 +30,7 @@ cleanup() {
     if [ "$SWAP_COMPLETE" -eq 0 ]; then
         psql -qtAX -c "DROP TABLE IF EXISTS observations_staging, photos_staging, taxa_staging, observers_staging CASCADE;" 2>/dev/null || true
     fi
-    # Release advisory lock
-    psql -qtAX -c "SELECT pg_advisory_unlock(1);" 2>/dev/null || true
+    # File lock is released automatically when the script exits
     # Clean up working files (cache is preserved)
     rm -f "${DATA_DIR}"/*.csv
 }
@@ -215,9 +214,10 @@ trap cleanup EXIT
 
 wait_for_postgres
 
-# Acquire advisory lock to prevent concurrent imports
-LOCK_ACQUIRED=$(psql -qtAX -c "SELECT pg_try_advisory_lock(1);")
-if [ "$LOCK_ACQUIRED" != "t" ]; then
+# Acquire file lock to prevent concurrent imports (held for entire script lifetime)
+LOCK_FILE="/tmp/import.lock"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
     log "ERROR: Another import is already in progress. Exiting."
     exit 1
 fi


### PR DESCRIPTION
### Bug Fixes

- **Importer not running** — Replaced `supercronic` (glibc binary incompatible with Alpine/musl) with Alpine's built-in `crond`.
- **Broken concurrent-import lock** — PostgreSQL advisory lock was session-scoped and released immediately; replaced with `mkdir`-based file lock.
- **Grafana panels failing** — Added empty materialized views at database init so panels load before first import; granted `pg_read_all_stats` for the Database Size panel.
- **Removed auto-import on startup** — Initial import no longer runs automatically; must be triggered manually or by cron schedule.

### Features

- **Skip unchanged imports** — Importer checks S3 ETags and skips the full import cycle when data hasn't changed and last import succeeded.
- **Health endpoint** — Added `v_health` SQL view exposed via PostgREST at `/v_health` for external uptime monitors.
- **La Selva Biological Station dashboard** — Observations, species, seasonal patterns, and map for the La Selva area in Costa Rica.
- **Steele Creek Park — Frogs dashboard** — Frog observations, species list, seasonal activity, and map for Steele Creek Park in Bristol, TN.
- **iNaturalist HotSpots dashboard** — Global observation density heatmap, top hotspots table, and distribution breakdown.

## Summary by Sourcery

Improve importer reliability, add health monitoring, and expand dashboards and documentation for operating the iNaturalist data platform.

New Features:
- Skip the full import cycle when S3 data has not changed since the last successful run using ETag-based caching.
- Expose a v_health view via PostgREST for external health checks of the import pipeline and dataset.
- Add new Grafana dashboards for La Selva Biological Station, Steele Creek Park frogs, and global iNaturalist hotspots.

Bug Fixes:
- Prevent concurrent imports using a file lock instead of a PostgreSQL advisory lock.
- Ensure Grafana panels load before the first import by creating empty materialized views at database initialization.
- Fix importer scheduling in Alpine by switching from supercronic to the built-in crond and updating the healthcheck.

Enhancements:
- Grant pg_read_all_stats to the main PostgreSQL user to support database size panels in Grafana.
- Simplify importer cleanup by dropping old tables with cascading dependencies.

Documentation:
- Document the new v_health health endpoint and how to query it via PostgREST.
- Add examples for filtered CSV data export using PostgREST query parameters.
- Introduce a development guide covering manual imports, seeding test data, testing alert SQL, rebuilding services, and viewing logs.