### PR TITLE
0.1.2 dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.1.2 — 2026-03-19
+
+### Bug Fixes
+
+- **Skip-unchanged logic never triggered** — The `import_log` row for the current run was inserted before the skip check, so the query always saw a `running` status instead of the previous completed one. Moved the INSERT to after the skip decision.
+- **Orphan import_log rows on skip** — Skipping an import left a row with NULL status/timestamps, which also broke the `v_health` view. Now no row is created when the import is skipped.
+- **Stale file lock blocks all future imports** — If the import process was killed uncleanly, the `/tmp/import.lock` directory was never removed. Added PID-based stale lock detection and automatic recovery.
+- **Staging index collision after first successful import** — `LIKE taxa INCLUDING ALL` copied indexes from the previous staging-turned-live tables, causing `CREATE INDEX idx_stg_*` to fail with "relation already exists". Replaced with `INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING GENERATED` to skip index copying.
+
+### Reliability
+
+- **`v_health` view filtered to finished imports** — Added `WHERE status IN ('completed', 'failed')` so the health endpoint only reports on completed or failed imports, not in-progress ones.
+
 ## v0.1.1 — 2026-03-19
 
 ### Bug Fixes

--- a/db/init/01-schema.sql
+++ b/db/init/01-schema.sql
@@ -77,6 +77,7 @@ SELECT
     il.duration_seconds AS last_import_duration_seconds,
     il.error_message AS last_error
 FROM import_log il
+WHERE il.status IN ('completed', 'failed')
 ORDER BY il.id DESC
 LIMIT 1;
 

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -135,10 +135,10 @@ DROP TABLE IF EXISTS observers_staging CASCADE;
 DROP TABLE IF EXISTS observations_staging CASCADE;
 DROP TABLE IF EXISTS photos_staging CASCADE;
 
-CREATE UNLOGGED TABLE taxa_staging (LIKE taxa INCLUDING ALL);
-CREATE UNLOGGED TABLE observers_staging (LIKE observers INCLUDING ALL);
-CREATE UNLOGGED TABLE observations_staging (LIKE observations INCLUDING ALL);
-CREATE UNLOGGED TABLE photos_staging (LIKE photos INCLUDING ALL);
+CREATE UNLOGGED TABLE taxa_staging (LIKE taxa INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING GENERATED);
+CREATE UNLOGGED TABLE observers_staging (LIKE observers INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING GENERATED);
+CREATE UNLOGGED TABLE observations_staging (LIKE observations INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING GENERATED);
+CREATE UNLOGGED TABLE photos_staging (LIKE photos INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING GENERATED);
 SQL
 
     log "Loading data into staging tables..."
@@ -217,15 +217,25 @@ wait_for_postgres
 
 # Acquire lock to prevent concurrent imports (mkdir is atomic)
 LOCK_DIR="/tmp/import.lock"
-if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-    log "ERROR: Another import is already in progress. Exiting."
+if mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo $$ > "$LOCK_DIR/pid"
+elif [ -f "$LOCK_DIR/pid" ]; then
+    LOCK_PID=$(cat "$LOCK_DIR/pid" 2>/dev/null || echo "")
+    if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
+        log "ERROR: Another import (PID $LOCK_PID) is already running. Exiting."
+        exit 1
+    fi
+    log "WARNING: Removing stale lock from PID $LOCK_PID"
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR"
+    echo $$ > "$LOCK_DIR/pid"
+else
+    log "ERROR: Lock exists but no PID file found. Remove $LOCK_DIR manually."
     exit 1
 fi
 
 log "=== iNaturalist import started ==="
 START_TIME=$(date +%s)
-
-IMPORT_ID=$(psql -qtAX -c "INSERT INTO import_log (started_at) VALUES (now()) RETURNING id;")
 
 download_files
 
@@ -238,6 +248,8 @@ if [ "$FILES_CHANGED" -eq 0 ]; then
     fi
     log "No new data but last import was not successful. Re-importing."
 fi
+
+IMPORT_ID=$(psql -qtAX -c "INSERT INTO import_log (started_at) VALUES (now()) RETURNING id;")
 
 validate_files
 load_staging


### PR DESCRIPTION
- **Skip-unchanged logic never triggered** — The `import_log` row for the current run was inserted before the skip check, so the query always saw a `running` status instead of the previous completed one. Moved the INSERT to after the skip decision.
- **Orphan import_log rows on skip** — Skipping an import left a row with NULL status/timestamps, which also broke the `v_health` view. Now no row is created when the import is skipped.
- **Stale file lock blocks all future imports** — If the import process was killed uncleanly, the `/tmp/import.lock` directory was never removed. Added PID-based stale lock detection and automatic recovery.
- **Staging index collision after first successful import** — `LIKE taxa INCLUDING ALL` copied indexes from the previous staging-turned-live tables, causing `CREATE INDEX idx_stg_*` to fail with "relation already exists". Replaced with `INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING GENERATED` to skip index copying.

## Summary by Sourcery

Update import process locking, skip logic, and health reporting for more reliable imports.

Bug Fixes:
- Prevent staging table index collisions by copying only defaults, constraints, and generated columns instead of all indexes from live tables.
- Fix import skip-when-unchanged logic so it evaluates against the previous completed import before inserting a new import_log row.
- Avoid creating orphan import_log rows when an import is skipped to keep health reporting consistent.
- Detect and recover from stale import lock directories using PID tracking to avoid permanently blocked imports.

Enhancements:
- Restrict v_health to only completed or failed imports to provide more meaningful health information.