### PR TITLE
V0.1.3 dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.1.3 — 2026-03-19
+
+### Bug Fixes
+
+- **Race condition in stale lock recovery** — After removing a stale lock, `mkdir` was not checked for failure, allowing two imports to run concurrently if another process grabbed the lock in between. Now aborts if re-acquisition fails.
+
 ## v0.1.2 — 2026-03-19
 
 ### Bug Fixes

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -227,7 +227,10 @@ elif [ -f "$LOCK_DIR/pid" ]; then
     fi
     log "WARNING: Removing stale lock from PID $LOCK_PID"
     rm -rf "$LOCK_DIR"
-    mkdir "$LOCK_DIR"
+    if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+        log "ERROR: Failed to re-acquire lock after stale cleanup. Another import may have started."
+        exit 1
+    fi
     echo $$ > "$LOCK_DIR/pid"
 else
     log "ERROR: Lock exists but no PID file found. Remove $LOCK_DIR manually."


### PR DESCRIPTION
- **Race condition in stale lock recovery** — After removing a stale lock, `mkdir` was not checked for failure, allowing two imports to run concurrently if another process grabbed the lock in between. Now aborts if re-acquisition fails.

## Summary by Sourcery

Fix locking behavior in the importer to prevent concurrent runs when recovering from stale locks.

Bug Fixes:
- Ensure the importer aborts if lock directory re-creation fails after removing a stale lock, avoiding concurrent imports.

Documentation:
- Document the v0.1.3 release and its lock recovery bug fix in the changelog.